### PR TITLE
Fix broken anchors for launch and private content sections

### DIFF
--- a/lms_lrs.md
+++ b/lms_lrs.md
@@ -102,7 +102,7 @@ of the associated entry is known, it should be declared. Where an entry is avail
 multiple languages, it should be repeated for each language. If the language is unknown,
 then the attribute should be left blank.
 
-<a name="launch" />
+<a name="launch" ></a>
 ### Launch
 
 TinCan APs(?) do not need to be launched from an LMS, however it is still an option. When
@@ -180,7 +180,7 @@ the activity. Minimally, the AP must be configured with the LRS endpoint, and us
 will also need authentication credentials.
 
 
-<a name="privateContent"/>
+<a name="privateContent"></a>
 ### Private Content Access and TinCan
 
 This section describes a companion specification to the Tin Can API for the purpose of


### PR DESCRIPTION
Having these as self-closing tags was breaking the formatting for these two sections.